### PR TITLE
Fix: Normalize composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,18 +2,21 @@
     "name": "simonhamp/routes",
     "type": "library",
     "description": "A low-level router class for PHP based on CodeIgniter's core/Router.php.",
-    "keywords": ["php", "routing"],
+    "keywords": [
+        "php",
+        "routing"
+    ],
     "homepage": "https://github.com/simonhamp/routes",
     "license": "MIT",
-    "require": {
-        "php": ">=5.3.0"
-    },
     "authors": [
         {
             "name": "Simon Hamp",
             "homepage": "http://simonhamp.me"
         }
     ],
+    "require": {
+        "php": ">=5.3.0"
+    },
     "autoload": {
         "psr-4": {
             "SimonHamp\\Routes\\": "src"


### PR DESCRIPTION
This PR

* [x] normalizes `composer.json`

Follows ae9714224a815b12248290885bb3778101e7e06f.

💁‍♂️ Ran

```
$ composer global require localheinz/composer-normalize
```

and then

```
$ composer normalize
```

For reference, see [`localheinz/composer-normalize`](https://github.com/localheinz/composer-normalize).